### PR TITLE
Carga web3 si el documento ya está cargado

### DIFF
--- a/client/src/getWeb3.js
+++ b/client/src/getWeb3.js
@@ -1,38 +1,43 @@
 import Web3 from "web3";
 
+const loadWeb3 = async (resolve, reject) => {
+  // Modern dapp browsers...
+  if (window.ethereum) {
+    const web3 = new Web3(window.ethereum);
+    try {
+      // Request account access if needed
+      await window.ethereum.enable();
+      // Acccounts now exposed
+      resolve(web3);
+    } catch (error) {
+      reject(error);
+    }
+  }
+  // Legacy dapp browsers...
+  else if (window.web3) {
+    // Use Mist/MetaMask's provider.
+    const web3 = window.web3;
+    console.log("Injected web3 detected.");
+    resolve(web3);
+  }
+  // Fallback to localhost; use dev console port by default...
+  else {
+    const provider = new Web3.providers.HttpProvider(
+      "http://127.0.0.1:8545"
+    );
+    const web3 = new Web3(provider);
+    console.log("No web3 instance injected, using Local web3.");
+    resolve(web3);
+  }
+}
+
 const getWeb3 = () =>
   new Promise((resolve, reject) => {
-    // Wait for loading completion to avoid race conditions with web3 injection timing.
-    window.addEventListener("load", async () => {
-      // Modern dapp browsers...
-      if (window.ethereum) {
-        const web3 = new Web3(window.ethereum);
-        try {
-          // Request account access if needed
-          await window.ethereum.enable();
-          // Acccounts now exposed
-          resolve(web3);
-        } catch (error) {
-          reject(error);
-        }
-      }
-      // Legacy dapp browsers...
-      else if (window.web3) {
-        // Use Mist/MetaMask's provider.
-        const web3 = window.web3;
-        console.log("Injected web3 detected.");
-        resolve(web3);
-      }
-      // Fallback to localhost; use dev console port by default...
-      else {
-        const provider = new Web3.providers.HttpProvider(
-          "http://127.0.0.1:8545"
-        );
-        const web3 = new Web3(provider);
-        console.log("No web3 instance injected, using Local web3.");
-        resolve(web3);
-      }
-    });
+    if (document.readyState === 'complete') {
+      loadWeb3(resolve, reject);
+    } else {
+      window.addEventListener("load", () => loadWeb3(resolve, reject));
+    }
   });
 
 export default getWeb3;


### PR DESCRIPTION
El problema es una race condition en getWeb3, y no tiene nada que ver con IPFS. El getWeb3 se cuelga del onload para ejecutar la lógica de cargar web3, pero como ahora hay varias operaciones que están corriendo antes del getWeb3, el evento onload ya se disparó para el momento en que getWeb3 llega a attachearse al evento. La solución es chequear si el documento ya está cargado, y en ese caso armar la instancia de web3, y si no, colgarse del onload como antes.